### PR TITLE
support for object refs

### DIFF
--- a/lib/text-input-mask.js
+++ b/lib/text-input-mask.js
@@ -58,6 +58,8 @@ export default class TextInputMask extends BaseTextComponent {
 
                         if (typeof this.props.refInput === 'function') {
                             this.props.refInput(ref)
+                        } else if (this.props.refInput && typeof this.props.refInput === 'object') {
+                            this.props.refInput.current = ref
                         }
                     }
                 }}


### PR DESCRIPTION
Prior to this PR, `inputRef` could not be a ref object, despite it being [the new standard](https://reactjs.org/docs/refs-and-the-dom.html#creating-refs).
Refs created with `React.createRef()` and `React.useRef()` are now supported.